### PR TITLE
Add "import whitelisted games only" feature

### DIFF
--- a/src/itch.py
+++ b/src/itch.py
@@ -20,7 +20,6 @@ KEYS_URL = 'https://api.itch.io/profile/owned-keys?page=%s'
 
 HOMEPAGE = 'https://www.itch.io'
 
-
 class ItchIntegration(Plugin):
     def __init__(self, reader, writer, token):
         super().__init__(
@@ -68,6 +67,7 @@ class ItchIntegration(Plugin):
         return Authentication(str(user.get("id")), str(user.get("username")))
 
     async def get_owned_games(self):
+        whitelist = await load_whitelist_from_file()
         page = 1
         games = []
         while True:
@@ -78,7 +78,7 @@ class ItchIntegration(Plugin):
                 raise
             if len(resp.get("owned_keys")) == 0:
                 return games
-            self.parse_json_into_games(resp.get("owned_keys"), games)
+            self.parse_json_into_games(resp.get("owned_keys"), games, whitelist)
             page += 1
         return games
 
@@ -87,7 +87,7 @@ class ItchIntegration(Plugin):
         self.authenticated = True
         return resp.get("user")
 
-    def parse_json_into_games(self, resp, games):
+    def parse_json_into_games(self, resp, games, whitelist):
         for key in resp:
             game = key.get("game")
             if not game.get("classification") == "game":
@@ -101,7 +101,12 @@ class ItchIntegration(Plugin):
                 game_title=game_name,
                 license_info=LicenseInfo(LicenseType.SinglePurchase),
                 dlcs=[])
-            games.append(this_game)
+            # If the whitelist is populated only add the games in the whitelist, else add all games
+            if (len(whitelist) > 0):
+                if (game_name in whitelist):
+                    games.append(this_game)
+            else:
+                games.append(this_game)
 
     async def get_os_compatibility(self, game_id, context):
         try:
@@ -124,6 +129,16 @@ def log(msg):
     log = open(os.path.join(os.path.dirname(__file__), "log2.txt"), "a")
     log.write(str(msg) + "\n")
     log.close()
+    
+# load whitelisted games from file            
+async def load_whitelist_from_file():
+    ret = []
+    if (os.path.isfile(Path(__file__).parent / 'whitelist.txt')):
+        with open(Path(__file__).parent / 'whitelist.txt', 'r') as f:
+            lines = f.readlines()
+            for l in lines:
+                ret.append(l.strip())
+    return ret
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## What
I've implemented a small additional feature for your gog itch integration, that would give users the option of only importing games listed on a whitelist.

## Why
I thought this would be a useful feature to have for users with a large library of games on itch (potentially from bundles that have 1000+ games). It would allow them to specify a smaller list of games that they want to import rather than their entire library.

## How
I've added a small function in `itch.py` that reads from a `whitelist.txt` file in the itch integration directory and adds each line in that file to a list. I've also slightly modified `get_owned_games` and `parse_json_into_games` to have the following behaviour:
* If the whitelist file doesn't exist or is empty the app will add every games in the user's library (like before). 
* Otherwise it'll check each game against the whitelist and only add games that appear in that whitelist.

## Testing
I tested the changes on Windows where I copied my modified `itch.py` file to the itch integration folder in the gog plugins directory. I also created a `whitelist.txt` file in the same directory and connected the plugin in GOG Galaxy 2.0, the integration had the expected behaviour of only importing the games whose names appeared in the whitelist file. 